### PR TITLE
Updated variables in config and init scripts

### DIFF
--- a/config.example.py
+++ b/config.example.py
@@ -6,7 +6,7 @@ import os
 DATABASE = dict(
     db=os.getenv("FAF_DB_NAME", "faf_test"),
     user=os.getenv("FAF_DB_LOGIN", "root"),
-    password=os.getenv("FAF_DB_PASSWORD", ""),
+    password=os.getenv("FAF_DB_PASSWORD", "banana"),
     host=os.getenv("DB_PORT_3306_TCP_ADDR", "127.0.0.1"),
     port=int(os.getenv("DB_PORT_3306_TCP_PORT", "3306")))
 

--- a/init_and_wait_for_db.sh
+++ b/init_and_wait_for_db.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+git clone https://github.com/FAForever/db.git db
 pushd db
 docker build -t faf-db .
 DB_CONTAINER=`docker run -d --name faf-db -e MYSQL_ROOT_PASSWORD=banana faf-db`


### PR DESCRIPTION
If cloning just the API repository, then the init script should auto fetch the db module from git. I also believe config.example.py should include the password that is used in the script. That does need to be modified if there is a custom install of the faf-db. Hence, I do believe the documentation addition should be added if there is a custom install of faf-db for some reason.