### PR TITLE
Ranked1v1 refactoring additions

### DIFF
--- a/api/ranked1v1.py
+++ b/api/ranked1v1.py
@@ -17,6 +17,8 @@ SELECT_EXPRESSIONS = {
     'deviation': 'r.deviation',
     'num_games': 'r.numGames',
     'won_games': 'r.winGames',
+    'lost_games': 'r.numGames - r.winGames',
+    'winning_percentage': 'ROUND((r.winGames/r.numGames) * 100)',
     'is_active': 'r.is_active',
     'rating': 'ROUND(r.mean - 3 * r.deviation)',
     'ranking': '@rownum:=@rownum+1'

--- a/api/ranked1v1.py
+++ b/api/ranked1v1.py
@@ -93,3 +93,11 @@ def ranked1v1_stats():
         data['rating_distribution'][str(int(item['rating']))] = item['count']
 
     return Ranked1v1StatsSchema().dump(data, many=False).data
+
+
+def append_select_expression():
+    select = SELECT_EXPRESSIONS.copy()
+    select['won_games'] = 'r.winGames'
+    select['lost_games'] = 'r.numGames - r.winGames'
+    select['winning_percentage'] = 'ROUND((r.winGames/r.numGames) * 100)'
+    return select

--- a/api/ranked1v1.py
+++ b/api/ranked1v1.py
@@ -46,6 +46,8 @@ def ranked1v1():
         where += " l.login LIKE %(player)s"
         args['player'] = '%' + player + '%'
 
+    append_select_expression()
+
     return fetch_data(Ranked1v1Schema(), TABLE1V1, SELECT_EXPRESSIONS, MAX_PAGE_SIZE, request, sort='-rating',
                       args=args, where=where)
 
@@ -58,6 +60,8 @@ def ranked1v1_get(player_id):
                                         AND is_active = 1
                                         AND numGames > 0)
                                         """
+
+    append_select_expression()
 
     result = fetch_data(Ranked1v1Schema(), TABLE1V1, select_expressions, MAX_PAGE_SIZE, request,
                         many=False, where='r.id=%(id)s', args=dict(id=player_id, row_num=0))
@@ -93,11 +97,3 @@ def ranked1v1_stats():
         data['rating_distribution'][str(int(item['rating']))] = item['count']
 
     return Ranked1v1StatsSchema().dump(data, many=False).data
-
-
-def append_select_expression():
-    select = SELECT_EXPRESSIONS.copy()
-    select['won_games'] = 'r.winGames'
-    select['lost_games'] = 'r.numGames - r.winGames'
-    select['winning_percentage'] = 'ROUND((r.winGames/r.numGames) * 100)'
-    return select

--- a/api/ranked1v1.py
+++ b/api/ranked1v1.py
@@ -16,9 +16,6 @@ SELECT_EXPRESSIONS = {
     'mean': 'r.mean',
     'deviation': 'r.deviation',
     'num_games': 'r.numGames',
-    'won_games': 'r.winGames',
-    'lost_games': 'r.numGames - r.winGames',
-    'winning_percentage': 'ROUND((r.winGames/r.numGames) * 100)',
     'is_active': 'r.is_active',
     'rating': 'ROUND(r.mean - 3 * r.deviation)',
     'ranking': '@rownum:=@rownum+1'

--- a/api/ranked1v1.py
+++ b/api/ranked1v1.py
@@ -25,6 +25,7 @@ SELECT_EXPRESSIONS = {
 }
 
 TABLE1V1 = 'ladder1v1_rating r JOIN login l on r.id = l.id, (SELECT @rownum:=%(row_num)s) n'
+TABLEGLOBAL = 'global_rating r JOIN login l on r.id = l.id, (SELECT @rownum:=%(row_num)s) n'
 
 
 @app.route('/ranked1v1')

--- a/api/ranked1v1.py
+++ b/api/ranked1v1.py
@@ -97,3 +97,11 @@ def ranked1v1_stats():
         data['rating_distribution'][str(int(item['rating']))] = item['count']
 
     return Ranked1v1StatsSchema().dump(data, many=False).data
+
+
+def append_select_expression():
+    select = SELECT_EXPRESSIONS.copy()
+    select['won_games'] = 'r.winGames'
+    select['lost_games'] = 'r.numGames - r.winGames'
+    select['winning_percentage'] = 'ROUND((r.winGames/r.numGames) * 100)'
+    return select

--- a/api/ranked1v1.py
+++ b/api/ranked1v1.py
@@ -46,9 +46,9 @@ def ranked1v1():
         where += " l.login LIKE %(player)s"
         args['player'] = '%' + player + '%'
 
-    append_select_expression()
+    select = append_select_expression()
 
-    return fetch_data(Ranked1v1Schema(), TABLE1V1, SELECT_EXPRESSIONS, MAX_PAGE_SIZE, request, sort='-rating',
+    return fetch_data(Ranked1v1Schema(), TABLE1V1, select, MAX_PAGE_SIZE, request, sort='-rating',
                       args=args, where=where)
 
 @app.route('/rating/<string:rating_type>')
@@ -86,16 +86,15 @@ def rating_type(rating_type):
 
 @app.route('/ranked1v1/<int:player_id>')
 def ranked1v1_get(player_id):
-    select_expressions = SELECT_EXPRESSIONS.copy()
-    select_expressions['ranking'] = """(SELECT count(*) FROM ladder1v1_rating
+    select = append_select_expression()
+
+    select['ranking'] = """(SELECT count(*) FROM ladder1v1_rating
                                         WHERE ROUND(mean - 3 * deviation) >= ROUND(r.mean - 3 * r.deviation)
                                         AND is_active = 1
                                         AND numGames > 0)
                                         """
 
-    append_select_expression()
-
-    result = fetch_data(Ranked1v1Schema(), TABLE1V1, select_expressions, MAX_PAGE_SIZE, request,
+    result = fetch_data(Ranked1v1Schema(), TABLE1V1, select, MAX_PAGE_SIZE, request,
                         many=False, where='r.id=%(id)s', args=dict(id=player_id, row_num=0))
 
     if 'id' not in result['data']:

--- a/api/ranked1v1.py
+++ b/api/ranked1v1.py
@@ -24,7 +24,7 @@ SELECT_EXPRESSIONS = {
     'ranking': '@rownum:=@rownum+1'
 }
 
-TABLE = 'ladder1v1_rating r JOIN login l on r.id = l.id, (SELECT @rownum:=%(row_num)s) n'
+TABLE1V1 = 'ladder1v1_rating r JOIN login l on r.id = l.id, (SELECT @rownum:=%(row_num)s) n'
 
 
 @app.route('/ranked1v1')
@@ -48,7 +48,7 @@ def ranked1v1():
         where += " l.login LIKE %(player)s"
         args['player'] = '%' + player + '%'
 
-    return fetch_data(Ranked1v1Schema(), TABLE, SELECT_EXPRESSIONS, MAX_PAGE_SIZE, request, sort='-rating',
+    return fetch_data(Ranked1v1Schema(), TABLE1V1, SELECT_EXPRESSIONS, MAX_PAGE_SIZE, request, sort='-rating',
                       args=args, where=where)
 
 
@@ -61,7 +61,7 @@ def ranked1v1_get(player_id):
                                         AND numGames > 0)
                                         """
 
-    result = fetch_data(Ranked1v1Schema(), TABLE, select_expressions, MAX_PAGE_SIZE, request,
+    result = fetch_data(Ranked1v1Schema(), TABLE1V1, select_expressions, MAX_PAGE_SIZE, request,
                         many=False, where='r.id=%(id)s', args=dict(id=player_id, row_num=0))
 
     if 'id' not in result['data']:

--- a/tests/unit_tests/test_ranked1v1.py
+++ b/tests/unit_tests/test_ranked1v1.py
@@ -12,6 +12,7 @@ def ranked1v1_ratings(request, app):
     with db.connection:
         cursor = db.connection.cursor()
         cursor.execute("TRUNCATE TABLE ladder1v1_rating")
+        cursor.execute("TRUNCATE TABLE global_rating")
         cursor.execute("TRUNCATE TABLE login")
         cursor.execute("""INSERT INTO login
         (id, login, password, email) VALUES
@@ -25,6 +26,12 @@ def ranked1v1_ratings(request, app):
         (2, 2000, 200, 20, 9, 1),
         (3, 1720, 100, 13, 7, 1),
         (4, 1500, 99, 30, 17, 1)""")
+        cursor.execute("""INSERT INTO global_rating
+        (id, mean, deviation, numGames, is_active) VALUES
+        (1, 800, 100, 5, 0),
+        (2, 500, 300, 2, 1),
+        (3, 1600, 200, 3, 1),
+        (4, 1800, 50, 20, 1)""")
 
     def finalizer():
         with db.connection:
@@ -170,3 +177,67 @@ def test_ranked1v1_stats(test_client, ranked1v1_ratings):
 
     result = json.loads(response.data.decode('utf-8'))
     assert result['data']['attributes']['rating_distribution'] == {'1200': 1, '1400': 2}
+
+def test_rating_invalid(test_client, ranked1v1_ratings):
+    response = test_client.get('/rating/')
+
+    assert response.status_code == 404
+
+def test_rating_1v1(test_client, ranked1v1_ratings):
+    response = test_client.get('/rating/1v1')
+
+    assert response.status_code == 200
+    assert response.content_type == 'application/vnd.api+json'
+
+    result = json.loads(response.data.decode('utf-8'))
+    assert 'data' in result
+    assert len(result['data']) == 4
+
+    for item in result['data']:
+        assert 'type' in item
+
+
+def test_rating_global(test_client, ranked1v1_ratings):
+    response = test_client.get('/rating/global')
+    assert response.status_code == 200
+    assert response.content_type == 'application/vnd.api+json'
+
+    result = json.loads(response.data.decode('utf-8'))
+    assert 'data' in result
+    assert len(result['data']) == 4
+
+    for item in result['data']:
+        assert 'type' in item
+
+def test_rating_get_player_invalid(test_client, ranked1v1_ratings):
+    response = test_client.get('/rating/lol/1')
+
+    assert response.status_code == 400
+    assert json.loads(response.get_data(as_text=True))['message'] == 'The rating type should be either 1v1 or global.'
+
+def test_rating_get_player_1v1(test_client, ranked1v1_ratings):
+    response = test_client.get('/rating/1v1/1')
+
+    schema = Ranked1v1Schema()
+
+    result, errors = schema.loads(response.data.decode('utf-8'))
+
+    assert response.status_code == 200
+    assert response.content_type == 'application/vnd.api+json'
+    assert not errors
+    assert result['login'] == 'a'
+    assert result['ranking'] == 1
+
+
+def test_rating_get_player_global(test_client, ranked1v1_ratings):
+    response = test_client.get('/rating/global/1')
+
+    schema = Ranked1v1Schema()
+
+    result, errors = schema.loads(response.data.decode('utf-8'))
+
+    assert response.status_code == 200
+    assert response.content_type == 'application/vnd.api+json'
+    assert not errors
+    assert result['login'] == 'a'
+    assert result['ranking'] == 3


### PR DESCRIPTION
Updated the Ranked1v1 endpoint for the API. I added a new endpoint for `/rating`. If someone accesses `/rating`, then they must specify a `1v1` or `global` argument. This will then get either the rank for 1v1's or global ratings. Added tests for the new endpoint.