### PR TITLE
Redirect email-validation links to faf main page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ services:
   - docker
 
 before_install:
+  - sudo /etc/init.d/mysql stop
   - sudo apt-get update
   - sudo apt-get -y install liblua5.1-dev libffi-dev
   - pushd db && ./setup_db.sh && popd

--- a/api/users_route.py
+++ b/api/users_route.py
@@ -134,7 +134,7 @@ def validate_account(token=None):
                 'deviation': deviation
             })
 
-    return "ok"
+    return redirect(app.config['ACCOUNT_ACTIVATION_REDIRECT'])
 
 
 @app.route('/users/reset_password', methods=['POST'])
@@ -248,7 +248,7 @@ def validate_password(token=None):
         if cursor.rowcount == 0:
             raise ApiException([Error(ErrorCode.PASSWORD_RESET_FAILED)])
 
-    return "ok"
+        return redirect(app.config['PASSWORD_RESET_REDIRECT'])
 
 
 @app.route('/users/change_password', methods=['POST'])

--- a/config.example.py
+++ b/config.example.py
@@ -44,3 +44,6 @@ MANDRILL_API_KEY = os.getenv("MANDRILL_API_KEY", '')
 MANDRILL_API_URL = os.getenv("MANDRILL_API_URL", 'https://mandrillapp.com/api/1.0')
 
 STEAM_LOGIN_URL = os.getenv("STEAM_LOGIN_URL", 'https://steamcommunity.com/openid/login')
+
+ACCOUNT_ACTIVATION_REDIRECT = 'http://www.faforever.com/account_activated'
+PASSWORD_RESET_REDIRECT = 'http://www.faforever.com/password_resetted'

--- a/tests/unit_tests/test_users_route.py
+++ b/tests/unit_tests/test_users_route.py
@@ -180,7 +180,8 @@ def test_validate_registration_success(test_client, setup_users):
         '/users/validate_registration/' + create_token('register', time.time() + 60, 'alpha', 'a@faforever.com',
                                                        '0000'))
 
-    assert response.status_code == 200
+    assert response.status_code == 302
+    assert response.headers['location'] == 'http://www.faforever.com/account_activated'
 
     with db.connection:
         cursor = db.connection.cursor(db.pymysql.cursors.DictCursor)
@@ -272,7 +273,8 @@ def test_validate_password_success(oauth, setup_users):
     response = oauth.get(
         '/users/validate_password/' + create_token('reset_password', time.time() + 60, 'abc', 'a@aa.aa', 'test123'))
 
-    assert response.status_code == 200
+    assert response.status_code == 302
+    assert response.headers['location'] == 'http://www.faforever.com/password_resetted'
 
     with db.connection:
         cursor = db.connection.cursor(db.pymysql.cursors.DictCursor)


### PR DESCRIPTION
Fixes #142 
validate_account now redirects to `http://www.faforever.com/account_activated`
validate_password now redirects to `http://www.faforever.com/password_resetted`
