### PR TITLE
URGENT Fix/147 invalid usernames

### DIFF
--- a/api/helpers.py
+++ b/api/helpers.py
@@ -14,7 +14,7 @@ import config
 from api.error import ApiException, Error, ErrorCode
 from config import CRYPTO_KEY
 
-USERNAME_REGEX = re.compile("[A-Za-z]{1}[A-Za-z0-9_-]{2,15}")
+USERNAME_REGEX = re.compile("[A-Za-z]{1}[A-Za-z0-9_-]{2,15}$")
 EMAIL_REGEX = re.compile(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$")
 
 

--- a/tests/unit_tests/test_helpers.py
+++ b/tests/unit_tests/test_helpers.py
@@ -52,7 +52,7 @@ def test_validate_username_success(setup_users):
 
 def test_validate_username_illegal_syntax(setup_users):
     with pytest.raises(ApiException) as excInfo:
-        validate_username("x,y")
+        validate_username("xxx yyy")
 
     assert excInfo.value.errors[0].code == ErrorCode.INVALID_USERNAME
 


### PR DESCRIPTION
The regex did not check the whole username. As soon as the first part of the username was valid, you could use illegal characters.