### PR TITLE
[WIP, Do not merge] Prevent name stealing by locking names

### DIFF
--- a/api/error.py
+++ b/api/error.py
@@ -215,6 +215,10 @@ class ErrorCode(Enum):
         code=150,
         title='Not allowed',
         detail='{0}')
+    USERNAME_CHANGE_RESTRICTED = dict(
+        code=151,
+        title='Username change not allowed (Name reserved)',
+        detail='This name has been used by another player within the last {} months and is therefore reserved. (Last used on {})')
 
 
 class Error:

--- a/api/users_route.py
+++ b/api/users_route.py
@@ -332,6 +332,7 @@ def change_name():
     validate_username(desired_name)
 
     with db.connection:
+        # Check if 30 days have passed since this user last changed their name
         cursor = db.connection.cursor()
         cursor.execute(
             "SELECT DATEDIFF(NOW(), change_time) as days_since_last_change FROM name_history WHERE user_id=%(id)s AND DATEDIFF(NOW(), change_time) < 30 ORDER BY change_time DESC",
@@ -343,6 +344,20 @@ def change_name():
 
         if entry is not None:
             raise ApiException([Error(ErrorCode.USERNAME_CHANGE_TOO_EARLY, 30 - int(entry[0]))])
+
+        # Check if 6 months have passed since requested name was last used
+        cursor.execute(
+            "SELECT change_time FROM name_history WHERE previous_name=%(name)s AND user_id !=%(id)s AND DATEDIFF(NOW(), change_time) < %(time)s ORDER BY change_time DESC",
+            {
+                'id': request.oauth.user.id,
+                'name': desired_name,
+                'time': 30*6 # 6 months
+            })
+
+        entry = cursor.fetchone()
+
+        if entry is not None:
+            raise ApiException([Error(ErrorCode.USERNAME_CHANGE_RESTRICTED, entry[0]]))
 
         cursor.execute(
             "INSERT INTO name_history (user_id, previous_name) SELECT id, login FROM login WHERE id = %(id)s",


### PR DESCRIPTION
When discussing name stealing with moderators, we came up with a simple mitigation: Lock names for 6 months.

This PR implements that names that were in use less than 6 months ago cannot be used (Except by original owner).