### PR TITLE
Add game verification to steamlink validation

### DIFF
--- a/api/users_route.py
+++ b/api/users_route.py
@@ -413,12 +413,22 @@ def link_to_steam():
 def validate_steam_request(token=None):
     user_id, redirect_to = decrypt_token('link_to_steam', token)
 
+    def validate_steam_redir(redirect_to, result, msg):
+        if result:
+            result = 'success'
+        else:
+            result = 'fail'
+        params = {'steam_link_result': result}
+        if msg is not None:
+            params['steam_link_msg'] = msg
+        redirect_to += ('&' if urlparse(redirect_to).query else '?') + urlencode(params)
+        return redirect(redirect_to)
+
     # extract steam account id
     match = re.search('^http://steamcommunity.com/openid/id/([0-9]{17,25})', request.args.get('openid.identity'))
 
     if match is None:
-        redirect_to += ('&' if urlparse(redirect_to).query else '?') + urlencode({'steam_link_result': 'fail'})
-        return redirect(redirect_to)
+        return validate_steam_redir(redirect_to, False, 'Could not find SteamID.')
 
     steamID = match.group(1)
 
@@ -435,10 +445,11 @@ def validate_steam_request(token=None):
             if game['appid'] == 9420:
                 found_game = True
                 break
+    else:
+        return validate_steam_redir(redirect_to, False, 'Could not look up games list - make sure your Steam profile is set to public.')
 
     if not found_game:
-        redirect_to += ('&' if urlparse(redirect_to).query else '?') + urlencode({'steam_link_result': 'fail'})
-        return redirect(redirect_to)
+        return validate_steam_redir(redirect_to, False, 'You do not appear to own Supreme Commander Forged Alliance on Steam.')
 
     with db.connection:
         cursor = db.connection.cursor()
@@ -449,9 +460,7 @@ def validate_steam_request(token=None):
                 'id': user_id
             })
 
-        redirect_to += ('&' if urlparse(redirect_to).query else '?') + urlencode({'steam_link_result': 'success'})
-        return redirect(redirect_to)
-
+        return validate_steam_redir(redirect_to, True, None)
 
 @app.route('/users/change_email', methods=['POST'])
 @oauth.require_oauth('write_account_data')

--- a/config.example.py
+++ b/config.example.py
@@ -64,3 +64,5 @@ STEAM_LOGIN_URL = os.getenv("STEAM_LOGIN_URL", 'https://steamcommunity.com/openi
 
 ACCOUNT_ACTIVATION_REDIRECT = 'http://www.faforever.com/account_activated'
 PASSWORD_RESET_REDIRECT = 'http://www.faforever.com/password_resetted'
+
+STEAM_API_KEY = os.getenv("STEAM_API_KEY", '')

--- a/tests/unit_tests/test_users_route.py
+++ b/tests/unit_tests/test_users_route.py
@@ -398,8 +398,9 @@ def test_validate_steam_fail(test_client, setup_users):
                                                                        'http://localhost?test=true') + '?openid.identity=http://steamcommunity.com/openid/id/no-steam-id')
 
     assert response.status_code == 302
-    assert response.headers['location'] == 'http://localhost?test=true&steam_link_result=fail'
-
+    # startswith / in because we don't care if there's a &steam_link_msg=... after it or what's in it
+    assert response.headers['location'].startswith('http://localhost?test=true')
+    assert 'steam_link_result=fail' in response.headers['location']
 
 #Cannot test without steam api key
 @pytest.mark.skip

--- a/tests/unit_tests/test_users_route.py
+++ b/tests/unit_tests/test_users_route.py
@@ -401,6 +401,8 @@ def test_validate_steam_fail(test_client, setup_users):
     assert response.headers['location'] == 'http://localhost?test=true&steam_link_result=fail'
 
 
+#Cannot test without steam api key
+@pytest.mark.skip
 def test_validate_steam_success(test_client, setup_users):
     response = test_client.get('/users/validate_steam/' + create_token('link_to_steam', time.time() + 60, 'abc',
                                                                        'http://faforever.com') + '?openid.identity=http://steamcommunity.com/openid/id/12345678901234567890')


### PR DESCRIPTION
Checks whether the linked Steam account has bought (owns) FA.

Also adds more feedback via `steam_link_msg` parameter.

TODO:
* [x] Test on test server
* [x] Update website to use new feedback message