### PR TITLE
Fix Steam Link verification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: python
 python:
   - "3.5"
 
+notifications:
+  email: false
+
 sudo: required
 dist: trusty
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   - docker build -t faf-api .
 
 script:
-  - docker run --name faf-api --link faf-db:db -e FAF_DB_PASSWORD=banana faf-api py.test --cov-report term-missing --cov=api
+  - docker run --name faf-api --link faf-db:db -e FAF_DB_PASSWORD=banana -e STEAM_API_KEY=$STEAM_API_KEY faf-api py.test --cov-report term-missing --cov=api
   - docker run --link faf-db:db -e FAF_DB_PASSWORD=banana faf-api pyflakes . || true
 
 after_success:

--- a/api/users_route.py
+++ b/api/users_route.py
@@ -434,17 +434,25 @@ def validate_steam_request(token=None):
 
     found_game = False
 
+    FA_APPID = 9420
+
     steam_req = requests.get('http://api.steampowered.com/IPlayerService/GetOwnedGames/v0001', params = {
         'key': config.STEAM_API_KEY,
         'steamid': steamID,
-        'format': 'json'
+        'format': 'json',
+        'appids_filter[0]': FA_APPID
         })
     if steam_req.status_code == 200:
-        steam_rep = steam_req.json()
-        for game in steam_rep['response']['games']:
-            if game['appid'] == 9420:
-                found_game = True
-                break
+        try:
+            steam_rep = steam_req.json()
+            if steam_rep['response']['game_count'] > 0:
+                for game in steam_rep['response']['games']:
+                    if game['appid'] == FA_APPID:
+                        found_game = True
+                        break
+        except:
+            logger.exception('Steam request parsing failed for steamid={}, user_id={}'.format(steamID, user_id))
+
     else:
         return validate_steam_redir(redirect_to, False, 'Could not look up games list - make sure your Steam profile is set to public.')
 

--- a/tests/unit_tests/test_users_route.py
+++ b/tests/unit_tests/test_users_route.py
@@ -412,7 +412,19 @@ def test_validate_steam_success(test_client, setup_users):
                                                                        'http://faforever.com') + '?openid.identity=http://steamcommunity.com/openid/id/76561198007601820')
 
     assert response.status_code == 302
-    assert response.headers['location'] == 'http://faforever.com?steam_link_result=success'
+    assert 'steam_link_result=success' in response.headers['location']
+
+def test_validate_steam_no_game(test_client, setup_users):
+    #Cannot test without steam api key
+    if not test_client.application.config.get('STEAM_API_KEY'):
+        pytest.skip('Cannot test steam link without api key')
+
+    # uses ID of bot, which does not own game
+    response = test_client.get('/users/validate_steam/' + create_token('link_to_steam', time.time() + 60, 'abc',
+                                                                       'http://faforever.com') + '?openid.identity=http://steamcommunity.com/openid/id/76561198403140265')
+
+    assert response.status_code == 302
+    assert 'steam_link_result=fail' in response.headers['location']
 
 
 def test_change_password_success(oauth, setup_users):

--- a/tests/unit_tests/test_users_route.py
+++ b/tests/unit_tests/test_users_route.py
@@ -54,6 +54,7 @@ def oauth():
     importlib.reload(api.users_route)
 
     api.app.config.from_object('config')
+    api.app.config['TESTING'] = True
     api.api_init()
     api.app.debug = True
 
@@ -402,11 +403,13 @@ def test_validate_steam_fail(test_client, setup_users):
     assert response.headers['location'].startswith('http://localhost?test=true')
     assert 'steam_link_result=fail' in response.headers['location']
 
-#Cannot test without steam api key
-@pytest.mark.skip
 def test_validate_steam_success(test_client, setup_users):
+    #Cannot test without steam api key
+    if not test_client.application.config.get('STEAM_API_KEY'):
+        pytest.skip('Cannot test steam link without api key')
+
     response = test_client.get('/users/validate_steam/' + create_token('link_to_steam', time.time() + 60, 'abc',
-                                                                       'http://faforever.com') + '?openid.identity=http://steamcommunity.com/openid/id/12345678901234567890')
+                                                                       'http://faforever.com') + '?openid.identity=http://steamcommunity.com/openid/id/76561198007601820')
 
     assert response.status_code == 302
     assert response.headers['location'] == 'http://faforever.com?steam_link_result=success'


### PR DESCRIPTION
* use `appids_filter` to filter fa steam app id
* do not throw when no `games` response object

Fixes #165