### PR TITLE
Set Flask LogLevel for aio run

### DIFF
--- a/run.py
+++ b/run.py
@@ -41,5 +41,7 @@ if __name__ == '__main__':
         from aiohttp_wsgi import serve
         from concurrent.futures import ThreadPoolExecutor
 
+        app.logger.setLevel(logging.INFO)
+
         with ThreadPoolExecutor(max_workers=1) as executor:
             serve(app, executor=executor, port=port)


### PR DESCRIPTION
Default Flask LogLevel is WARNING, but we definitely want to see INFO
messages